### PR TITLE
Makes the headers white in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -37,6 +37,9 @@
   --ifm-color-primary-light: #29d5b0;
   --ifm-color-primary-lighter: #32d8b4;
   --ifm-color-primary-lightest: #4fddbf;
+/*Dark mode header colours*/
+  --ifm-heading-color: #FFFFFF;
+  --ifm-font-color-base-inverse: #FFFFFF;
 }
 
 .docusaurus-highlight-code-line {


### PR DESCRIPTION
<img width="989" alt="image" src="https://user-images.githubusercontent.com/33951316/169825093-d6cee18c-1799-4530-be7b-6e346b7c53c0.png">


Black dark mode text changed to white

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/33951316/169825170-1fbfbf4d-733a-4732-8cf1-41fdeb18a1fb.png">
